### PR TITLE
Convert specs to RSpec 3.5.4 syntax with Transpec

### DIFF
--- a/spec/classes/fish_centos_spec.rb
+++ b/spec/classes/fish_centos_spec.rb
@@ -12,15 +12,15 @@ describe 'fish' do
 
     context 'repo disabled' do
       let(:params) {{ 'manage_repo' => false }}
-      it { should_not contain_yumrepo('shells_fish_release_2') }
+      it { is_expected.not_to contain_yumrepo('shells_fish_release_2') }
     end
 
     context 'repo enabled' do
       let(:params) {{ 'manage_repo' => true }}
-      it { should contain_class('fish::Repo::Centos')}
+      it { is_expected.to contain_class('fish::Repo::Centos')}
 
       it do
-        should contain_yumrepo('shells_fish_release_2').with(
+        is_expected.to contain_yumrepo('shells_fish_release_2').with(
           :descr    => 'Fish shell - 2.x release series (CentOS_7)',
           :baseurl  => 'http://download.opensuse.org/repositories/shells:/fish:/release:/2/CentOS_7/',
           :enabled  => '1',

--- a/spec/classes/fish_fedora_spec.rb
+++ b/spec/classes/fish_fedora_spec.rb
@@ -12,16 +12,16 @@ describe 'fish' do
 
     context 'repo disabled' do
       let(:params) {{ 'manage_repo' => false }}
-      it { should_not contain_yumrepo('shells_fish_release_2') }
+      it { is_expected.not_to contain_yumrepo('shells_fish_release_2') }
     end
 
     context 'repo enabled' do
       let(:params) {{ 'manage_repo' => true }}
 
-      it { should contain_class('fish::repo::fedora') }
+      it { is_expected.to contain_class('fish::repo::fedora') }
 
       it do
-        should contain_yumrepo('shells_fish_release_2').with(
+        is_expected.to contain_yumrepo('shells_fish_release_2').with(
           :ensure              => 'present',
           :descr               => 'Fish shell - 2.x release series (Fedora_22)',
           :baseurl             => 'http://download.opensuse.org/repositories/shells:/fish:/release:/2/Fedora_22/',

--- a/spec/classes/fish_ubuntu_spec.rb
+++ b/spec/classes/fish_ubuntu_spec.rb
@@ -16,15 +16,15 @@ describe 'fish' do
 
     context 'repo disabled' do
       let(:params) {{ 'manage_repo' => false }}
-      it { should_not contain_class('fish::repo::ubuntu')}
-      it { should_not contain_apt__ppa('ppa:fish-shell/release-2')}
-      it { should_not contain_exec('fish-add-apt-repository-ppa:fish-shell/release-2')}
+      it { is_expected.not_to contain_class('fish::repo::ubuntu')}
+      it { is_expected.not_to contain_apt__ppa('ppa:fish-shell/release-2')}
+      it { is_expected.not_to contain_exec('fish-add-apt-repository-ppa:fish-shell/release-2')}
     end
 
     context 'repo enabled' do
       let(:params) {{ 'manage_repo' => true }}
-      it { should contain_class('fish::repo::ubuntu')}
-      it { should contain_apt__ppa('ppa:fish-shell/release-2')}
+      it { is_expected.to contain_class('fish::repo::ubuntu')}
+      it { is_expected.to contain_apt__ppa('ppa:fish-shell/release-2')}
     end
   end
 end

--- a/spec/classes/fish_unsupported_spec.rb
+++ b/spec/classes/fish_unsupported_spec.rb
@@ -10,7 +10,7 @@ describe 'fish' do
       }
       end
 
-      it { expect { should create_class('fish') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
+      it { expect { is_expected.to create_class('fish') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
     end
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 3.3.0 with the following command:
    transpec

* 7 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 5 conversions
    from: it { should_not ... }
      to: it { is_expected.not_to ... }

For more details: https://github.com/yujinakayama/transpec#supported-conversions